### PR TITLE
addPhoto from an InputStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ if (order.getSubmissionStatus().isValid()) {
 Download
 --------
 
-Best to checkout, then run `gradle install`. Then you can just add this to your gradle deps: `compile 'uk.co.mattburns.pwinty:pwinty-java-sdk:2.2.5' `
+Best to checkout, then run `gradle install`. Then you can just add this to your gradle deps: `compile 'uk.co.mattburns.pwinty:pwinty-java-sdk:2.2.6' `
 
 Alternatively, add the jar to your project. You can find the jar in the [build directory]
 (https://github.com/mattburns/pwinty-java-sdk/tree/master/build/libs)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A java library for communicating with the [Pwinty API](http://www.pwinty.com/api
 v2.2 of the API is supported. If you want an older version, use an older build ;)
 
 
+Releases
+--------
+* v2.2.5 - Added ability to add a photo via an InputStream as well as a File or URL.
 
 Usage
 -----
@@ -41,7 +44,7 @@ if (order.getSubmissionStatus().isValid()) {
 Download
 --------
 
-Best to checkout, then run `gradle install`. Then you can just add this to your gradle deps: `compile 'uk.co.mattburns.pwinty:pwinty-java-sdk:2.2.4' `
+Best to checkout, then run `gradle install`. Then you can just add this to your gradle deps: `compile 'uk.co.mattburns.pwinty:pwinty-java-sdk:2.2.5' `
 
 Alternatively, add the jar to your project. You can find the jar in the [build directory]
 (https://github.com/mattburns/pwinty-java-sdk/tree/master/build/libs)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ v2.2 of the API is supported. If you want an older version, use an older build ;
 
 Releases
 --------
-* v2.2.5 - Added ability to add a photo via an InputStream as well as a File or URL.
+* v2.2.6 - Added ability to add a photo via an InputStream as well as a File or URL.
 
 Usage
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'uk.co.mattburns.pwinty'
-version '2.2.5'
+version '2.2.6'
 
 apply plugin: 'java'
 apply plugin: 'maven'
@@ -35,6 +35,7 @@ dependencies {
     compile 'com.google.code.gson:gson:2.3'
 
     testCompile 'junit:junit:4.+'
+
 }
 
 test {

--- a/src/main/java/uk/co/mattburns/pwinty/v2_2/Order.java
+++ b/src/main/java/uk/co/mattburns/pwinty/v2_2/Order.java
@@ -1,6 +1,7 @@
 package uk.co.mattburns.pwinty.v2_2;
 
 import java.io.File;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -295,6 +296,17 @@ public class Order {
      * File is uploaded.
      */
     public Photo addPhoto(File photo, Photo.Type type, int copies, Sizing sizing) {
+        Photo addedPhoto = pwinty.addPhotoToOrder(id, photo, type, copies,
+                sizing);
+        getPhotos().add(addedPhoto);
+        return addedPhoto;
+    }
+
+    /**
+     * Add a photo byte[] InputStream object to the order. This method will block until the
+     * File is uploaded.
+     */
+    public Photo addPhoto(InputStream photo, Photo.Type type, int copies, Sizing sizing) {
         Photo addedPhoto = pwinty.addPhotoToOrder(id, photo, type, copies,
                 sizing);
         getPhotos().add(addedPhoto);

--- a/src/main/java/uk/co/mattburns/pwinty/v2_2/Pwinty.java
+++ b/src/main/java/uk/co/mattburns/pwinty/v2_2/Pwinty.java
@@ -37,17 +37,14 @@ public class Pwinty {
     /**
      * This is the main class for talking to the Pwinty API. See
      * http://www.pwinty.com/api.html for detailed examples.
-     *
+     * <p/>
      * For all method calls, if an error occurs, a {@link PwintyError} will be
      * thrown
      *
-     * @param environment
-     *            Choose SANDBOX for testing and LIVE for real orders you wish
-     *            to print
-     * @param merchantId
-     *            As supplied by http://www.pwinty.com
-     * @param apiKey
-     *            As supplied by http://www.pwinty.com
+     * @param environment Choose SANDBOX for testing and LIVE for real orders you wish
+     *                    to print
+     * @param merchantId  As supplied by http://www.pwinty.com
+     * @param apiKey      As supplied by http://www.pwinty.com
      */
     public Pwinty(Environment environment, String merchantId, String apiKey) {
         this(null, environment, merchantId, apiKey);
@@ -56,43 +53,35 @@ public class Pwinty {
     /**
      * This is the main class for talking to the Pwinty API. See
      * http://www.pwinty.com/api.html
-     * 
-     * @param environment
-     *            Choose SANDBOX for testing and LIVE for real orders you wish
-     *            to print
-     * @param merchantId
-     *            As supplied by http://www.pwinty.com
-     * @param apiKey
-     *            As supplied by http://www.pwinty.com
-     * @param loggingStream
-     *            Requests and responses will be written to this
+     *
+     * @param environment   Choose SANDBOX for testing and LIVE for real orders you wish
+     *                      to print
+     * @param merchantId    As supplied by http://www.pwinty.com
+     * @param apiKey        As supplied by http://www.pwinty.com
+     * @param loggingStream Requests and responses will be written to this
      */
     public Pwinty(Environment environment, String merchantId, String apiKey,
-            PrintStream loggingStream) {
+                  PrintStream loggingStream) {
         this(new LoggingFilter(loggingStream), environment, merchantId, apiKey);
     }
 
     /**
      * This is the main class for talking to the Pwinty API. See
      * http://www.pwinty.com/api.html
-     * 
-     * @param environment
-     *            Choose SANDBOX for testing and LIVE for real orders you wish
-     *            to print
-     * @param merchantId
-     *            As supplied by http://www.pwinty.com
-     * @param apiKey
-     *            As supplied by http://www.pwinty.com
-     * @param logger
-     *            Requests and responses will be written to this
+     *
+     * @param environment Choose SANDBOX for testing and LIVE for real orders you wish
+     *                    to print
+     * @param merchantId  As supplied by http://www.pwinty.com
+     * @param apiKey      As supplied by http://www.pwinty.com
+     * @param logger      Requests and responses will be written to this
      */
     public Pwinty(Environment environment, String merchantId, String apiKey,
-            Logger logger) {
+                  Logger logger) {
         this(new LoggingFilter(logger), environment, merchantId, apiKey);
     }
 
     private Pwinty(LoggingFilter loggingFilter, Environment environment,
-            String merchantId, String apiKey) {
+                   String merchantId, String apiKey) {
         this.merchantId = merchantId;
         this.apiKey = apiKey;
 
@@ -119,12 +108,10 @@ public class Pwinty {
 
     /**
      * Get the most recent orders.
-     * 
-     * @param count
-     *            The number of order to retrieve
-     * @param offset
-     *            Skip over this many most recent orders
-     * @return  A list of orders
+     *
+     * @param count  The number of order to retrieve
+     * @param offset Skip over this many most recent orders
+     * @return A list of orders
      */
     public List<Order> getOrders(int count, int offset) {
         String ordersJSON = webResource.path("Orders")
@@ -205,14 +192,14 @@ public class Pwinty {
     }
 
     Issues getIssues(int orderId) {
-            ClientResponse response = webResource
-                    .path("Orders/" + orderId + "/Issues")
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .header("X-Pwinty-MerchantId", merchantId)
-                    .header("X-Pwinty-REST-API-Key", apiKey)
-                    .get(ClientResponse.class);
+        ClientResponse response = webResource
+                .path("Orders/" + orderId + "/Issues")
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header("X-Pwinty-MerchantId", merchantId)
+                .header("X-Pwinty-REST-API-Key", apiKey)
+                .get(ClientResponse.class);
 
-            return createReponse(response, Issues.class);
+        return createReponse(response, Issues.class);
     }
 
     /**
@@ -220,7 +207,7 @@ public class Pwinty {
      * File is uploaded.
      */
     Photo addPhotoToOrder(int orderId, File photo, Photo.Type type, int copies,
-            Sizing sizing) {
+                          Sizing sizing) {
         return addPhotoToOrder(orderId, null, photo, null, type, copies, sizing);
     }
 
@@ -237,7 +224,7 @@ public class Pwinty {
      * Add a photo to the order using a public URL.
      */
     Photo addPhotoToOrder(int orderId, URL photoUrl, Photo.Type type,
-            int copies, Sizing sizing) {
+                          int copies, Sizing sizing) {
         return addPhotoToOrder(orderId, null, null, photoUrl, type, copies, sizing);
     }
 
@@ -245,7 +232,7 @@ public class Pwinty {
      * Either the File or URL must be supplied
      */
     private Photo addPhotoToOrder(int orderId, InputStream photoData, File photo, URL photoUrl,
-            Photo.Type type, int copies, Sizing sizing) {
+                                  Photo.Type type, int copies, Sizing sizing) {
 
         @SuppressWarnings("resource")
         FormDataMultiPart form = new FormDataMultiPart()
@@ -253,7 +240,7 @@ public class Pwinty {
                 .field("sizing", sizing.toString())
                 .field("copies", "" + copies);
 
-        if(photoData != null) {
+        if (photoData != null) {
             form.bodyPart(new StreamDataBodyPart("file", photoData));
         } else if (photo != null) {
             form.bodyPart(new FileDataBodyPart("file", photo,
@@ -324,7 +311,7 @@ public class Pwinty {
 
     /**
      * Submit the Order for printing and shipping
-     * 
+     * <p/>
      * If an error occurs, a {@link PwintyError} will be thrown
      */
     void submitOrder(int orderId) {
@@ -435,8 +422,7 @@ public class Pwinty {
      * Test if Pwinty have started offering new print sizes currently not
      * hard-coded in the enum Photo.Type
      *
-     * @param countryCodes
-     *            countries to check (just an optimisation).
+     * @param countryCodes countries to check (just an optimisation).
      * @return set of item names we don't handle
      */
     protected Set<String> getUnrecognisedItemNames(CountryCode... countryCodes) {
@@ -462,7 +448,7 @@ public class Pwinty {
 
     /**
      * Get the set of items we dont recognise from the catalogue
-     * 
+     *
      * @param catalogue The catalogue to check
      */
     private Set<CatalogueItem> getUnrecognisedItems(Catalogue catalogue) {

--- a/src/test/java/uk/co/mattburns/pwinty/v2_2/OrderTest.java
+++ b/src/test/java/uk/co/mattburns/pwinty/v2_2/OrderTest.java
@@ -1,24 +1,9 @@
 package uk.co.mattburns.pwinty.v2_2;
 
-import static org.junit.Assert.*;
-import static uk.co.mattburns.pwinty.v2_2.CountryCode.GB;
-import static uk.co.mattburns.pwinty.v2_2.CountryCode.US;
-import static uk.co.mattburns.pwinty.v2_2.CountryCode.AU;
-
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.List;
-import java.util.Properties;
-
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.joda.time.DateTime;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-
+import org.junit.*;
 import uk.co.mattburns.pwinty.v2_2.Order.QualityLevel;
 import uk.co.mattburns.pwinty.v2_2.Order.Status;
 import uk.co.mattburns.pwinty.v2_2.Photo.Sizing;
@@ -27,8 +12,17 @@ import uk.co.mattburns.pwinty.v2_2.Pwinty.Environment;
 import uk.co.mattburns.pwinty.v2_2.SubmissionStatus.GeneralError;
 import uk.co.mattburns.pwinty.v2_2.gson.TypeDeserializer;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+import static uk.co.mattburns.pwinty.v2_2.CountryCode.*;
 
 public class OrderTest {
 
@@ -339,6 +333,29 @@ public class OrderTest {
         URL url = new URL(TEST_PHOTO_URL);
 
         order.addPhoto(url, Type._4x6, 1, Sizing.Crop);
+
+        SubmissionStatus submissionStatus = order.getSubmissionStatus();
+
+        assertEquals(
+                "SubmissionStatus is not valid: " + submissionStatus.toString(),
+                true, submissionStatus.isValid());
+    }
+
+    @Test
+    public void can_create_and_add_photo_by_data() throws IOException {
+        Order order = new Order(pwinty, GB, GB, QualityLevel.Standard, false);
+        order.setAddress1("ad1");
+        order.setAddress2("ad2");
+        order.setAddressTownOrCity("toc");
+        order.setPostalOrZipCode("zip");
+        order.setRecipientName("bloggs");
+        order.setStateOrCounty("bristol");
+
+        assertEquals(Status.NotYetSubmitted, order.getStatus());
+
+        InputStream stream = getClass().getResourceAsStream("test.jpg");
+
+        order.addPhoto(stream, Type._4x6, 1, Sizing.Crop);
 
         SubmissionStatus submissionStatus = order.getSubmissionStatus();
 


### PR DESCRIPTION
In this version, API users can add photos to orders from an InputStream, rather than being limited to a URL which may be private, or a File which may be impossible on things such as GAE apps.

I've also incremented the minor version by 1 to reflect this non-breaking/backward-compatible change in the API, and added a Releases section to the README.
